### PR TITLE
Fixing project settings that lead to intermittent build errors

### DIFF
--- a/Bandwidth Voice Ref App.xcodeproj/project.pbxproj
+++ b/Bandwidth Voice Ref App.xcodeproj/project.pbxproj
@@ -596,6 +596,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = Q2MF3NHN7B;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -624,6 +625,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = Q2MF3NHN7B;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Bandwidth Voice Ref App.xcodeproj/project.pbxproj
+++ b/Bandwidth Voice Ref App.xcodeproj/project.pbxproj
@@ -376,6 +376,7 @@
 				TargetAttributes = {
 					15B2E66F1ACD573B003BDD65 = {
 						CreatedOnToolsVersion = 6.2;
+						DevelopmentTeam = Q2MF3NHN7B;
 						LastSwiftMigration = 0800;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
@@ -447,7 +448,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# this assumes the app will have \"Debug\" and \"Release\" configurations. It creates a symlink\n# ACTIVE which leads to Debug or Release Softphone framework. The framework from ACTIVE directory\n# will then be embedded into the resulting .app\nif [[ ! -e ${PROJECT_DIR}/libsoftphone ]]; then\n    unzip ${PROJECT_DIR}/libsoftphone*.zip -d ${PROJECT_DIR}/libsoftphone;\n    ln -s ${PROJECT_DIR}/libsoftphone/Frameworks/ali.framework ${PROJECT_DIR}/libsoftphone/ali.framework;\nfi\n\nln -sf ${PROJECT_DIR}/libsoftphone/Frameworks/${CONFIGURATION}/Softphone.framework ${PROJECT_DIR}/libsoftphone/Softphone.framework";
+			shellScript = "# this assumes the app will have \"Debug\" and \"Release\" configurations. It creates a symlink\n# ACTIVE which leads to Debug or Release Softphone framework. The framework from ACTIVE directory\n# will then be embedded into the resulting .app\nif [[ ! -e ${PROJECT_DIR}/libsoftphone ]]; then\n    unzip ${PROJECT_DIR}/libsoftphone*.zip -d ${PROJECT_DIR}/libsoftphone;\n    cp -R ${PROJECT_DIR}/libsoftphone/Frameworks/ali.framework ${PROJECT_DIR}/libsoftphone/ali.framework;\nfi\n\ncp -Rf ${PROJECT_DIR}/libsoftphone/Frameworks/${CONFIGURATION}/Softphone.framework ${PROJECT_DIR}/libsoftphone/Softphone.framework";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Bandwidth Voice Ref App.xcodeproj/project.pbxproj
+++ b/Bandwidth Voice Ref App.xcodeproj/project.pbxproj
@@ -596,6 +596,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/libsoftphone",
@@ -623,6 +624,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/libsoftphone",


### PR DESCRIPTION
- Reverting to copying the Acrobits' SDKs, since symlinking it lead to errors.
- Disabling bitcode, since Acrobits' SDK doesn't support it.
- Specifying Bandwidth as the development team.